### PR TITLE
Compatibility with ggplot2 4.0.0

### DIFF
--- a/R/scale_alpha_focus.R
+++ b/R/scale_alpha_focus.R
@@ -20,7 +20,7 @@ scale_alpha_focus <- function(focus_levels, alpha_focus = 1,
 
 #' @export
 #' @method ggplot_add ggfocus_alpha
-ggplot_add.ggfocus_alpha <- function(object, plot, object_name){
+ggplot_add.ggfocus_alpha <- function(object, plot, ...){
 
   p1 <- plot
   focus_levels <- object$focus_levels

--- a/R/scale_color_focus.R
+++ b/R/scale_color_focus.R
@@ -38,7 +38,7 @@ scale_color_focus <- function(focus_levels, color_focus = NULL,
 
 #' @export
 #' @method ggplot_add ggfocus_color
-ggplot_add.ggfocus_color <- function(object, plot, object_name){
+ggplot_add.ggfocus_color <- function(object, plot, ...){
 
   p1 <- plot
   focus_levels <- object$focus_levels

--- a/R/scale_fill_focus.R
+++ b/R/scale_fill_focus.R
@@ -17,7 +17,7 @@ scale_fill_focus <- function(focus_levels, color_focus = NULL,
 
 #' @export
 #' @method ggplot_add ggfocus_fill
-ggplot_add.ggfocus_fill <- function(object, plot, object_name){
+ggplot_add.ggfocus_fill <- function(object, plot, ...){
 
   p1 <- plot
   focus_levels <- object$focus_levels

--- a/R/scale_linetype_focus.R
+++ b/R/scale_linetype_focus.R
@@ -15,7 +15,7 @@ scale_linetype_focus <- function(focus_levels, linetype_focus = 1,
 
 #' @export
 #' @method ggplot_add ggfocus_linetype
-ggplot_add.ggfocus_linetype <- function(object, plot, object_name){
+ggplot_add.ggfocus_linetype <- function(object, plot, ...){
 
   p1 <- plot
   focus_levels <- object$focus_levels

--- a/R/scale_shape_focus.R
+++ b/R/scale_shape_focus.R
@@ -22,7 +22,7 @@ scale_shape_focus <- function(focus_levels,
 
 #' @export
 #' @method ggplot_add ggfocus_shape
-ggplot_add.ggfocus_shape <- function(object, plot, object_name){
+ggplot_add.ggfocus_shape <- function(object, plot, ...){
 
   p1 <- plot
   focus_levels <- object$focus_levels

--- a/R/scale_size_focus.R
+++ b/R/scale_size_focus.R
@@ -22,7 +22,7 @@ scale_size_focus <- function(focus_levels,
 
 #' @export
 #' @method ggplot_add ggfocus_size
-ggplot_add.ggfocus_size <- function(object, plot, object_name){
+ggplot_add.ggfocus_size <- function(object, plot, ...){
 
   p1 <- plot
   focus_levels <- object$focus_levels


### PR DESCRIPTION
Hi there,

We've been preparing a new major release for ggplot2 and found an issue during a reverse dependency check.
The issue is described in https://github.com/tidyverse/ggplot2/issues/6515, where you're welcome to raise discussion.
This PR aims to solve that issue for this package.

In addition, we detected an issue in the examples of the `ggfocus()` function, but couldn't replicate this locally. This is just to alert you that this PR might potentially miss a different issue.

You can test your code with the development version of ggplot2 by installing it as follows:

```r
# install.packages("pak")
pak::pak("tidyverse/ggplot2")
```

We aim to release the new ggplot2 version in about 2 weeks, and hope you can submit an update to CRAN around that time. Hopefully this will inform you in a timely manner.

Best wishes,
Teun